### PR TITLE
Pass options specified for the toJSON() method to the child toJSON() methods

### DIFF
--- a/src/backbone.associate.js
+++ b/src/backbone.associate.js
@@ -121,7 +121,7 @@
 
         for (key in associations) {
           if (_isAssociatedType(associations[key], attributes[key])) {
-            attributes[key] = attributes[key].toJSON();
+            attributes[key] = attributes[key].toJSON(options);
           }
         }
         return attributes;

--- a/test/backbone.associate.spec.js
+++ b/test/backbone.associate.spec.js
@@ -14,6 +14,11 @@
   var M = Backbone.Model.extend({}),
       N = Backbone.Model.extend({}),
       O = Backbone.Model.extend({}),
+      P = Backbone.Model.extend({
+        toJSON: function( options ) {
+          return options;
+        }
+      }),
       C = Backbone.Collection.extend({
         model: N
       });
@@ -24,6 +29,7 @@
       this.modelA = M;
       this.modelB = N;
       this.modelC = O;
+      this.modelD = P;
       this.collectionB = C;
 
       this.associations = {
@@ -290,6 +296,22 @@
         this.parent.manies().reset(expected);
         result = this.parent.toJSON();
         expect(result.manies).toEqual(expected);
+      });
+
+      describe('when options are specified', function () {
+
+        it('should pass the options to the child model\'s toJSON method', function () {
+          var Parent = Backbone.Model.extend({});
+          Backbone.associate( Parent, {
+            child: { type:this.modelD }
+          });
+
+          var p = new Parent(),
+              options = {},
+              result = p.toJSON( options );
+
+          expect( result.child ).toEqual( options );
+        });
       });
     });
 


### PR DESCRIPTION
I wanted to add options to a `toJSON()` override in one of my child models. I looked and saw that options are passed to Backbone's `toJSON()` method, but they aren't passed from the parent model's `toJSON()` to the child model's `toJSON()`. This pull request fixes that issue.