### PR TITLE
Update Backbone namespace extension

### DIFF
--- a/src/backbone.associate.js
+++ b/src/backbone.associate.js
@@ -11,9 +11,11 @@
 
   'use strict';
 
-  // CommonJS compatibilty
-  if (typeof window == 'undefined') {
-    factory(require('underscore'), require('backbone'));
+  // Node.js or CommonJS compatibilty
+  if (typeof exports !== 'undefined') {
+    var Backbone = require('backbone');
+    var _ = require('underscore');
+    module.exports = factory(_, Backbone);
   }
   else if (typeof define === "function" && define.amd) {
     // AMD. Register as an anonymous module.


### PR DESCRIPTION
Modifies the extension of Backbone namespace to avoid TypeError.

Using browserify for nodejs after doing:

```
var Backbone = require('backbone');
requre('backbone-associate');

Backbone.associate()
```

A TypeError was thrown when calling associate as Backbone was undefined.
After making the changes found in the PR, the above pattern works with
no issues.

Nodejs: 4.x
Backbone: 1.2x and 1.3.x


Continuation of #25 